### PR TITLE
vehicle spawn and version check (hive- ext)

### DIFF
--- a/BreakingPointExt/BreakingPointExt.cpp
+++ b/BreakingPointExt/BreakingPointExt.cpp
@@ -32,6 +32,7 @@
 
 #include <boost/progress.hpp>
 
+
 typedef boost::function<Sqf::Value(Sqf::Parameters)> HandlerFunc;
 map<int, HandlerFunc> handlers;
 
@@ -838,12 +839,9 @@ Sqf::Value BreakingPointExt::vehicleCreate(Sqf::Parameters params)
 	Sqf::Value inventory = boost::get<Sqf::Parameters>(params.at(3));
 	Sqf::Value hitPoints = boost::get<Sqf::Parameters>(params.at(4));
 	double fuel = Sqf::GetDouble(params.at(5));
-	Int64 uniqueID = Sqf::GetBigInt(params.at(6));
+	string id = "0";
 
-	if (uniqueID > 0)
-		return booleanReturn(database->createVehicle(className, damage, worldSpace, inventory, hitPoints, fuel, uniqueID));
-
-	return booleanReturn(true);
+	return database->createVehicle(className, damage, worldSpace, inventory, hitPoints, fuel, id);
 };
 
 Sqf::Value BreakingPointExt::vehicleDelete(Sqf::Parameters params)
@@ -1101,6 +1099,13 @@ std::string BreakingPointExt::callExtension(std::string function)
 	try
 	{
 		res = handler(params);
+#ifdef DEV
+		// log it if debug is enabled
+		if (threadingDebug)
+		{
+			console->log("callExtensionResult: " + lexical_cast<string>(res), ArmaConsole::LogType::CRITICAL);
+		}
+#endif
 	}
 	catch (Poco::Data::MySQL::ConnectionException& ex)
 	{

--- a/BreakingPointExt/BreakingPointExt.cpp
+++ b/BreakingPointExt/BreakingPointExt.cpp
@@ -53,13 +53,16 @@ BreakingPointExt::BreakingPointExt(std::string a_serverFolder, int a_serverPort)
 	boost::property_tree::ini_parser::read_ini(serverFolder + "/BreakingPointExt.ini", pt);
 	int totalSlots = pt.get<int>("VIP.slots", 100);
 	int reservedSlots = pt.get<int>("VIP.reserved", 10);
+	std::string fireDeamonActiveStr = pt.get<std::string>("FIREDAEMON.active", "false");
 	std::string serviceName = pt.get<std::string>("FIREDAEMON.service", "BPA3_1");
 	std::string fireDaemonPath = pt.get<std::string>("FIREDAEMON.path", "C:/Program Files/FireDaemon/Firedaemon.exe");
 	std::string serverPassword = pt.get<std::string>("RCON.password", "rconpw");
 	std::string whitelistStr = pt.get<std::string>("RCON.whitelist", "false");
 	int rconPort = pt.get<int>("RCON.port", 2305);
 	whitelist = false;
+	fireDeamonActive = false;
 	if (whitelistStr == "true") { whitelist = true; }
+	if (fireDeamonActiveStr == "true") { fireDeamonActive = true; }
 	threadingDebug = pt.get<bool>("THREADING.debug", false);
 	int threadingSize = pt.get<int>("THREADING.size", 100);
 	int threadingDelay = pt.get<int>("THREADING.delay", 50);
@@ -74,7 +77,7 @@ BreakingPointExt::BreakingPointExt(std::string a_serverFolder, int a_serverPort)
 	//Init Rcon
 	rcon = new Rcon();
 	rcon->updateLogin("127.0.0.1", rconPort, serverPassword);
-	rcon->init(totalSlots, reservedSlots, serviceName, fireDaemonPath, whitelist);
+	rcon->init(totalSlots, reservedSlots, fireDeamonActive, serviceName, fireDaemonPath, whitelist);
 
 	//Init Async Worker
 	asyncWorker = new AsyncWorker(threadingDebug,threadingSize,threadingDelay);

--- a/BreakingPointExt/BreakingPointExt.cpp
+++ b/BreakingPointExt/BreakingPointExt.cpp
@@ -31,13 +31,16 @@
 #include <boost/property_tree/ini_parser.hpp>
 
 #include <boost/progress.hpp>
-
+//#define DEV
 
 typedef boost::function<Sqf::Value(Sqf::Parameters)> HandlerFunc;
 map<int, HandlerFunc> handlers;
 
 BreakingPointExt::BreakingPointExt(std::string a_serverFolder, int a_serverPort)
 {
+	//Extension Version
+	versionNum = "0.001";
+
 	//Load Args
 	serverFolder = a_serverFolder;
 	serverPort = a_serverPort;
@@ -230,8 +233,10 @@ Sqf::Value BreakingPointExt::serverBootup(Sqf::Parameters params)
 	database->connect();
 	
 	loaded = true;
-	
-	return booleanReturn(true);
+
+	Sqf::Parameters retVal;
+	retVal.push_back(versionNum);
+	return retVal;
 };
 
 Sqf::Value BreakingPointExt::serverShutdown(Sqf::Parameters params)

--- a/BreakingPointExt/BreakingPointExt.h
+++ b/BreakingPointExt/BreakingPointExt.h
@@ -27,6 +27,7 @@ class BreakingPointExt
 
 		bool loaded;
 		bool whitelist;
+		bool fireDeamonActive;
 		bool threadingDebug;
 
 		int timeUntilRestart();

--- a/BreakingPointExt/BreakingPointExt.h
+++ b/BreakingPointExt/BreakingPointExt.h
@@ -23,6 +23,8 @@ class BreakingPointExt
 		std::string callExtension(std::string function);
 		static Sqf::Parameters BreakingPointExt::booleanReturn(bool isGood);
 
+		std::string versionNum;
+
 		bool loaded;
 		bool whitelist;
 		bool threadingDebug;

--- a/BreakingPointExt/BreakingPointExt.vcxproj
+++ b/BreakingPointExt/BreakingPointExt.vcxproj
@@ -22,25 +22,25 @@
     <ProjectGuid>{19D09818-8232-406C-BEE5-71D70E744A5C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>BreakingPointExt</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <CLRSupport>false</CLRSupport>
@@ -48,7 +48,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <CLRSupport>false</CLRSupport>

--- a/BreakingPointExt/Database.cpp
+++ b/BreakingPointExt/Database.cpp
@@ -949,7 +949,6 @@ Sqf::Value Database::fetchCharacterDetails(int characterID)
 	}
 };
 
-
 bool Database::clearActiveServer(int characterID, string playerID)
 {
 	if (characterID > 0)
@@ -1106,7 +1105,6 @@ bool Database::updateObjectInventory(Int64 objectIdent, Sqf::Value& inventory)
 	stmt << "update `instance_deployable` set `inventory` = ? where `unique_id` = ? and `instance_id` = ?", use(inventoryStr), use(objectIdent), use(serverID), now;
 	return true;
 };
-
 
 Sqf::Value Database::createVehicle(string className, double damage, Sqf::Value worldSpace, Sqf::Value inventory, Sqf::Value hitPoints, double fuel,string id)
 {

--- a/BreakingPointExt/Database.cpp
+++ b/BreakingPointExt/Database.cpp
@@ -1014,7 +1014,7 @@ bool Database::updateCharacter(int characterID, const FieldsType& fields)
 			}
 		}
 		//other stats
-		else if (name == "zombie_kills" || name == "headshots" || name == "survival_time" || name == "survivor_kills" || name == "lastserver" || name == "class" || name == "ranger" || name == "outlaw" || name == "hunter" || name == "nomad" || name == "survivalist")
+		else if (name == "zombie_kills" || name == "headshots" || name == "survival_time" || name == "survivor_kills" || name == "lastserver" || name == "class" || name == "ranger" || name == "outlaw" || name == "hunter" || name == "nomad" || name == "survivalist" || name == "engineer")
 		{
 			sqlFields[name] = "'" + lexical_cast<string>(val)+"'";
 		}
@@ -1033,7 +1033,7 @@ bool Database::updateCharacter(int characterID, const FieldsType& fields)
 		{
 			string fieldName = it->first;
 
-			if (fieldName == "ranger" || fieldName == "outlaw" || fieldName == "hunter" || fieldName == "nomad" || fieldName == "survivalist") {
+			if (fieldName == "ranger" || fieldName == "outlaw" || fieldName == "hunter" || fieldName == "nomad" || fieldName == "survivalist" || fieldName == "engineer") {
 				joinProfile = true;
 				setClause += "p.`" + fieldName + "` = " + it->second;
 			}

--- a/BreakingPointExt/Database.h
+++ b/BreakingPointExt/Database.h
@@ -62,6 +62,7 @@ extern int serverID;
 extern ArmaConsole * console;
 
 class Database
+
 {
 	private:
 		Poco::Data::Session * activeSession;
@@ -115,7 +116,7 @@ class Database
 		bool updateObjectInventory(Int64 objectIdent, Sqf::Value& inventory);
 		bool deleteObject(Int64 objectIdent);
 
-		bool createVehicle(string className, double damage, Sqf::Value worldSpace, Sqf::Value inventory, Sqf::Value hitPoints, double fuel, Int64 uniqueID);
+		Sqf::Value createVehicle(string className, double damage, Sqf::Value worldSpace, Sqf::Value inventory, Sqf::Value hitPoints, double fuel, string id);
 		bool deleteVehicle(Int64 objectIdent);
 		bool updateVehicleInventory(Int64 objectIdent, Sqf::Value& inventory);
 		bool timestampVehicle(Int64 uniqueID);
@@ -135,5 +136,6 @@ class Database
 		bool storageLog(string playerID, string playerName, string deployableID, string deployableName, string ownerID);
 		bool hackLog(string playerID, string playerName, string reason);
 		bool kickLog(string name, string guid, string kick);
+		Sqf::Value getLastInsertId();
 		bool adminLog(string playerID, string playerName, string action);
 };

--- a/BreakingPointExt/Main.cpp
+++ b/BreakingPointExt/Main.cpp
@@ -37,7 +37,10 @@
 
 #include <boost/progress.hpp>
 
-extern "C" { __declspec (dllexport) void __stdcall RVExtension(char *output, int outputSize, const char *function); }
+extern "C" { 
+	__declspec (dllexport) void __stdcall RVExtension(char *output, int outputSize, const char *function);
+	__declspec (dllexport) void __stdcall RVExtensionVersion(char* output, int outputSize);
+}
 
 int serverID = 0;
 bool worker_working = false; //worker working status
@@ -188,6 +191,11 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function)
 	} else {
 		strncpy_s(output, outputSize, "INVALID COMMAND", _TRUNCATE); // other input 
 	}
+}
+
+void __stdcall RVExtensionVersion(char* output, int outputSize)
+{
+	strncpy_s(output, outputSize, breakingPointExt->versionNum.c_str(), _TRUNCATE);
 }
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved)

--- a/BreakingPointExt/Rcon.cpp
+++ b/BreakingPointExt/Rcon.cpp
@@ -685,7 +685,7 @@ void Rcon::disconnect()
 	*rcon_run_flag = false;
 }
 
-void Rcon::init(int a_totalSlots, int a_reservedSlots, std::string a_serviceName, std::string a_fireDaemonPath, bool a_whitelist)
+void Rcon::init(int a_totalSlots, int a_reservedSlots, bool a_fireDeamonActive , std::string a_serviceName, std::string a_fireDaemonPath, bool a_whitelist)
 {
 	whitelist = a_whitelist;
 	lastWarningMinute = -1; 
@@ -694,6 +694,7 @@ void Rcon::init(int a_totalSlots, int a_reservedSlots, std::string a_serviceName
 	reservedSlots = a_reservedSlots;
 	serviceName = a_serviceName;
 	fireDaemonPath = a_fireDaemonPath;
+	fireDeamonActive = a_fireDeamonActive;
 
 	createKeepAlive();
 }
@@ -708,11 +709,13 @@ void Rcon::updateLogin(std::string address, int port, std::string password)
 	rcon_login.auto_reconnect = true;
 }
 
-
 void Rcon::restart()
 {
 	console->log("Rcon::Restart()", ArmaConsole::LogType::DEBUG);
 	//std::string command = "start \"\" \"C:\\Program Files (x86)\\FireDaemon\\Firedaemon.exe\" --restart " + serviceName;
-	std::string command = "start \"\" \"" + fireDaemonPath + "\""" --restart " + serviceName;
-	system(command.c_str());
+	if (fireDeamonActive)
+	{
+		std::string command = "start \"\" \"" + fireDaemonPath + "\""" --restart " + serviceName;
+		system(command.c_str());
+	}
 }

--- a/BreakingPointExt/Rcon.h
+++ b/BreakingPointExt/Rcon.h
@@ -43,7 +43,7 @@ class Rcon : public Poco::Runnable
 		Rcon();
 		~Rcon();
 
-		void init(int a_totalSlots, int a_reservedSlots, std::string a_serviceName, std::string a_fireDaemonPath, bool a_whitelist);
+		void init(int a_totalSlots, int a_reservedSlots, bool fireDeamonActive, std::string a_serviceName, std::string a_fireDaemonPath, bool a_whitelist);
 		void updateLogin(std::string address, int port, std::string password);
 
 		void run();
@@ -80,6 +80,7 @@ class Rcon : public Poco::Runnable
 
 		int totalSlots;
 		int reservedSlots;
+		bool fireDeamonActive;
 		std::string serviceName;
 		std::string fireDaemonPath;
 		int lastWarningMinute;

--- a/ServerConfig/BreakingPointExt.ini
+++ b/ServerConfig/BreakingPointExt.ini
@@ -1,6 +1,7 @@
 [FIREDAEMON]
+active = false
 service = BPA3_1
-path = C:/Program Files/FireDaemon/Firedaemon.exe
+path = C:/Program Files (x86)/FireDaemon/Firedaemon.exe
 
 [DATABASE]
 ip = 127.0.0.1
@@ -14,7 +15,7 @@ slots = 100
 reserved = 10
 
 [RCON]
-port = 2305
+port = 2306
 password = changeme
 whitelist = false
 


### PR DESCRIPTION
Fixed the vehicle spawnig which was caused by the calculated unique_id. The problem was that if another vehicle spawned at the same position it could happen that two vehicles had the same id and that caused collisions an restart.

Added a version number to the extension and the server side pbo, if they do not match the server will not boot. This update requiers a server side (breakingpoint_server.pbo) update aswell!!!

Added a setting to activate firedaemon so it can be deactivated to stop the extension calling a command on the set path, which could cause a error or a explorer window to popup.

This update can be deployed into a runnig server with out a problem.
The extension returns from now on the inserted id from a row. That id will be used ingame to identify a vehicle and updated it back to the Database.